### PR TITLE
Do not instantiate racket/gui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+compiled/

--- a/rsvg/rsvg.rkt
+++ b/rsvg/rsvg.rkt
@@ -1,4 +1,4 @@
-#lang racket/gui
+#lang racket
 
 ;; FFI bindings to the RSVG library
 


### PR DESCRIPTION
This library doesn't need racket/gui, so don't instantiate it
unnecessarily.

The instantiation is problematic when rsvg is used in phase 1
(say, inside `compiled-bitmap` of
https://docs.racket-lang.org/images/Embedding_Bitmaps_in_Compiled_Files.html).
The instantiation in phase 1 will prevent another instantiation in
phase 0 with an error:

```
cannot instantiate `racket/gui/base’ a second time in the same process
```